### PR TITLE
Making fail fast mode for finagle configurable

### DIFF
--- a/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -295,7 +295,7 @@ object DruidBeams
 
             override def finagleHttpConnectionsPerHost = 2
 
-            override def finagleEnableFailedFastExceptions = true
+            override def finagleEnableFailFast = true
           },
           disco
         )

--- a/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -294,6 +294,8 @@ object DruidBeams
             override def finagleHttpTimeout = 90.seconds
 
             override def finagleHttpConnectionsPerHost = 2
+
+            override def finagleEnableFailedFastExceptions = true
           },
           disco
         )

--- a/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistry.scala
+++ b/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistry.scala
@@ -52,7 +52,7 @@ class FinagleRegistry(config: FinagleRegistryConfig, disco: Disco) extends Loggi
       .timeout(config.finagleHttpTimeout.standardDuration)
       .logger(FinagleLogger)
       .daemon(true)
-      .failFast(config.finagleEnableFailedFastExceptions)
+      .failFast(config.finagleEnableFailFast)
       .build()
     new SharedService(
       new ServiceProxy(client)

--- a/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistry.scala
+++ b/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistry.scala
@@ -52,7 +52,7 @@ class FinagleRegistry(config: FinagleRegistryConfig, disco: Disco) extends Loggi
       .timeout(config.finagleHttpTimeout.standardDuration)
       .logger(FinagleLogger)
       .daemon(true)
-      .failFast(false) // Generally only one server behind each service (there's one service per Druid task)
+      .failFast(config.finagleEnableFailedFastExceptions)
       .build()
     new SharedService(
       new ServiceProxy(client)

--- a/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistryConfig.scala
+++ b/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistryConfig.scala
@@ -24,5 +24,5 @@ trait FinagleRegistryConfig
 
   def finagleHttpConnectionsPerHost: Int
 
-  def finagleEnableFailedFastExceptions: Boolean
+  def finagleEnableFailFast: Boolean
 }

--- a/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistryConfig.scala
+++ b/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistryConfig.scala
@@ -23,4 +23,6 @@ trait FinagleRegistryConfig
   def finagleHttpTimeout: Period
 
   def finagleHttpConnectionsPerHost: Int
+
+  def finagleEnableFailedFastExceptions: Boolean
 }


### PR DESCRIPTION
I already had this code change pending so I figured I'd make a pull request for it.  I tried 0.3.4 but setting it to false actually made things worse (retries cause new peons to fill up middle managers), so at this time I think it is probably best to leave the default fail fast as True.