### PR TITLE
[BACKEND-616] Defaulting buildV9Directly to true

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidTuning.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidTuning.scala
@@ -26,7 +26,7 @@ case class DruidTuning(
   maxRowsInMemory: Int = 75000,
   intermediatePersistPeriod: Period = 10.minutes,
   maxPendingPersists: Int = 0,
-  buildV9Directly: Boolean = false
+  buildV9Directly: Boolean = true
 )
 
 object DruidTuning
@@ -38,15 +38,17 @@ object DruidTuning
     * @param maxRowsInMemory number of rows to aggregate before persisting
     * @param intermediatePersistPeriod period that determines the rate at which intermediate persists occur
     * @param maxPendingPersists number of persists that can be pending, but not started
+    * @param buildV9Directly should Druid be asked to build v9 segments directly
     */
   @deprecated("use 'apply' or 'builder'", "0.7.3")
   def create(
     maxRowsInMemory: Int,
     intermediatePersistPeriod: Period,
-    maxPendingPersists: Int
+    maxPendingPersists: Int,
+    buildV9Directly: Boolean
   ): DruidTuning =
   {
-    apply(maxRowsInMemory, intermediatePersistPeriod, maxPendingPersists)
+    apply(maxRowsInMemory, intermediatePersistPeriod, maxPendingPersists, buildV9Directly)
   }
 
   /**
@@ -81,7 +83,7 @@ object DruidTuning
       * Should Druid be asked to build v9 segments directly? Only supported in certain versions of Druid.
       * See your Druid version's documentation for details.
       *
-      * Default is false.
+      * Default is true.
       */
     def buildV9Directly(x: Boolean) = new Builder(config.copy(buildV9Directly = x))
 

--- a/core/src/test/resources/tranquility-core.json
+++ b/core/src/test/resources/tranquility-core.json
@@ -45,7 +45,7 @@
           "type" : "realtime",
           "intermediatePersistPeriod" : "PT45S",
           "maxRowsInMemory" : "100000",
-          "buildV9Directly" : "true",
+          "buildV9Directly" : "false",
           "windowPeriod" : "PT30S"
         }
       }

--- a/core/src/test/resources/tranquility-core.yaml
+++ b/core/src/test/resources/tranquility-core.yaml
@@ -30,7 +30,7 @@ dataSources:
         maxRowsInMemory: 100000
         intermediatePersistPeriod: PT45S
         windowPeriod: PT30S
-        buildV9Directly: true
+        buildV9Directly: false
 
     properties:
       task.partitions: 3

--- a/core/src/test/scala/com/metamx/tranquility/test/ConfigHelperTest.scala
+++ b/core/src/test/scala/com/metamx/tranquility/test/ConfigHelperTest.scala
@@ -50,7 +50,7 @@ class ConfigHelperTest extends FunSuite with ShouldMatchers
       builder.config._rollup.get.aggregators.map(_.getName) should be(Seq("count", "x"))
       builder.config._druidTuning.get.maxRowsInMemory should be(100000)
       builder.config._druidTuning.get.intermediatePersistPeriod should be(new Period("PT45S"))
-      builder.config._druidTuning.get.buildV9Directly should be(true)
+      builder.config._druidTuning.get.buildV9Directly should be(false)
       builder.config._tuning.get.windowPeriod should be(new Period("PT30S"))
     }
   }
@@ -73,7 +73,7 @@ class ConfigHelperTest extends FunSuite with ShouldMatchers
       builder.config._rollup.get.aggregators.map(_.getName) should be(Seq("count", "x"))
       builder.config._druidTuning.get.maxRowsInMemory should be(100000)
       builder.config._druidTuning.get.intermediatePersistPeriod should be(new Period("PT45S"))
-      builder.config._druidTuning.get.buildV9Directly should be(true)
+      builder.config._druidTuning.get.buildV9Directly should be(false)
       builder.config._tuning.get.windowPeriod should be(new Period("PT30S"))
     }
   }
@@ -96,7 +96,7 @@ class ConfigHelperTest extends FunSuite with ShouldMatchers
       builder.config._rollup.get.aggregators.map(_.getName) should be(Seq("count", "x"))
       builder.config._druidTuning.get.maxRowsInMemory should be(75000)
       builder.config._druidTuning.get.intermediatePersistPeriod should be(new Period("PT10M"))
-      builder.config._druidTuning.get.buildV9Directly should be(false)
+      builder.config._druidTuning.get.buildV9Directly should be(true)
       builder.config._tuning.get.windowPeriod should be(new Period("PT10M"))
     }
   }


### PR DESCRIPTION
Defaulting `buildV9Directly` to true and releasing a new version that will be used by `starfire-core` to allow for easy enabling across all pipelines